### PR TITLE
fix(TrackNotes): 修復進度條節點消失問題

### DIFF
--- a/apps/docs/stories/TrackNotes.stories.tsx
+++ b/apps/docs/stories/TrackNotes.stories.tsx
@@ -54,6 +54,10 @@ export const TrackNotes = createPluginStory({
     config: {
       height: 360,
       width: 640,
+      // 新版本的播放器不支援 custom cueType 了，需要加這個設定才行
+      timeSlider: {
+        legacy: true,
+      },
     },
     file: "https://cdn.jwplayer.com/manifests/GXbUbwm0.m3u8",
     library: "https://cdn.jwplayer.com/libraries/5vuW2BEP.js",


### PR DESCRIPTION
I found that the latest version of the player v8.30.1, the `addCues` API is not work, but the Biannual version (8.18.4) works fine.

If you change `cueType` from `custom` to `chapters` there should be no issue. Altenatively you can add to continue to use `custom`. You can see my example below:

```
timeSlider: {
  legacy: true
}
```

https://s3.amazonaws.com/kevinap.success.jwplayer.com/83177_set_cues.html